### PR TITLE
Refactor API client usage in tests

### DIFF
--- a/tests-api/apiClient.ts
+++ b/tests-api/apiClient.ts
@@ -1,19 +1,38 @@
 import { APIRequestContext, APIResponse } from "@playwright/test";
 
 export class ApiClient {
-  //Al declarar la propiedad request como private, TypeScript crea automáticamente la propiedad y la inicializa  
+  private static readonly basePath = "/api";
+
+  //Al declarar la propiedad request como private, TypeScript crea automáticamente la propiedad y la inicializa
   constructor(private request: APIRequestContext) {}
 
+  private buildUrl(path: string): string {
+    return `${ApiClient.basePath}${path}`;
+  }
+
+  private buildHeaders(extraHeaders: Record<string, string> = {}): Record<string, string> {
+    return {
+      "x-api-key": "reqres-free-v1",
+      ...extraHeaders
+    };
+  }
+
   async login(data: object): Promise<APIResponse> {
-    return await this.request.post("/api/login", {
+    return await this.request.post(this.buildUrl("/login"), {
       data,
-      headers: {
-        "x-api-key": "reqres-free-v1"
-      }
+      headers: this.buildHeaders()
     });
   }
 
   async getUsers(page: number = 1): Promise<APIResponse> {
-    return await this.request.get(`/api/users?page=${page}`);
+    return await this.request.get(this.buildUrl(`/users?page=${page}`), {
+      headers: this.buildHeaders()
+    });
+  }
+
+  async getUser(id: number): Promise<APIResponse> {
+    return await this.request.get(this.buildUrl(`/users/${id}`), {
+      headers: this.buildHeaders()
+    });
   }
 }

--- a/tests-api/tests/users-schema.spec.ts
+++ b/tests-api/tests/users-schema.spec.ts
@@ -2,19 +2,15 @@ import { test, expect } from "@playwright/test";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import schema from "../schemas/user-schema.json";
+import { ApiClient } from "../apiClient";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
 const validate = ajv.compile(schema);
 
 test("GET /users → validación de esquema con AJV", async ({ request }) => {
-    const headers = {
-        "x-api-key": "reqres-free-v1"
-    };
-
-    const response = await request.get("/api/users?page=2", {
-        headers: headers
-    });
+    const apiClient = new ApiClient(request);
+    const response = await apiClient.getUsers(2);
     expect(response.status()).toBe(200);
 
     const body = await response.json();

--- a/tests-api/tests/users.spec.ts
+++ b/tests-api/tests/users.spec.ts
@@ -55,11 +55,8 @@ test("GET /users?page=2 → validación de paginación", async ({ request }) => 
 });
 
 test("GET /users/23 → 404 Usuario no existe", async ({ request }) => {
-    const response = await request.get('/api/users/23', {
-        headers: {
-            "x-api-key": "reqres-free-v1"
-        }
-    });
+    const apiClient = new ApiClient(request);
+    const response = await apiClient.getUser(23);
 
     //Validamos el status code
     expect(response.status()).toBe(404);


### PR DESCRIPTION
## Summary
- centralize common request configuration inside `ApiClient`, including base path and API key header
- update users-related API tests to call the shared client instead of duplicating request setup
- reuse the API client in the schema validation test to keep request configuration consistent

## Testing
- `npx playwright test tests-api/tests` *(fails: network access to reqres.in is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a5544f8083318d9e382b2b93f6cf