### PR TITLE
Configure Playwright web server for API tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,4 +4,10 @@ export default defineConfig({
   use: {
     baseURL: process.env.MOCK_PRUEBA_BASE_URL || "http://127.0.0.1:3000",
   },
+  webServer: {
+    command: "node src/api/server.js",
+    port: Number(process.env.MOCK_PRUEBA_PORT) || 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000
+  }
 });


### PR DESCRIPTION
## Summary
- configure Playwright to launch the local API server before running tests
- allow port overrides via MOCK_PRUEBA_PORT while reusing existing server locally

## Testing
- `npx playwright test tests-api/tests`


------
https://chatgpt.com/codex/tasks/task_e_68e2022f47608331968a64fadbc2363f