### PR TITLE
feat: add Playwright API client fixture

### DIFF
--- a/tests-api/fixtures/apiClient.fixture.ts
+++ b/tests-api/fixtures/apiClient.fixture.ts
@@ -1,0 +1,20 @@
+import { test as base, expect } from "@playwright/test";
+import { ApiClient } from "../apiClient";
+import users from "./users.json";
+
+type ApiClientFixtures = {
+  apiClient: ApiClient;
+  users: typeof users;
+};
+
+export const test = base.extend<ApiClientFixtures>({
+  apiClient: async ({ request }, use) => {
+    const client = new ApiClient(request);
+    await use(client);
+  },
+  users: async ({}, use) => {
+    await use(users);
+  }
+});
+
+export { expect };

--- a/tests-api/tests/login/login.spec.ts
+++ b/tests-api/tests/login/login.spec.ts
@@ -1,9 +1,6 @@
-import { test, expect } from "@playwright/test";
-import users from "../../fixtures/users.json";
-import { ApiClient } from "../../apiClient";
+import { test, expect } from "../../fixtures/apiClient.fixture";
 
-test("POST /login válido → 200 OK + token no vacío", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("POST /login válido → 200 OK + token no vacío", async ({ apiClient, users }) => {
     const response = await apiClient.login(users.validUser);
 
     const body = await response.json();
@@ -19,8 +16,7 @@ test("POST /login válido → 200 OK + token no vacío", async ({ request }) => 
     expect(body.token.length).toBeGreaterThan(0);
 });
 
-test("POST /login sin password → 400 Bad Request", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("POST /login sin password → 400 Bad Request", async ({ apiClient, users }) => {
     const response = await apiClient.login({ email: users.validUser.email });
     
     expect(response.status()).toBe(400);
@@ -32,8 +28,7 @@ test("POST /login sin password → 400 Bad Request", async ({ request }) => {
 });
 
 
-test("POST /login sin email → 400 Bad Request", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("POST /login sin email → 400 Bad Request", async ({ apiClient, users }) => {
     const response = await apiClient.login({ password: users.validUser.password });
     
     expect(response.status()).toBe(400);
@@ -46,8 +41,7 @@ test("POST /login sin email → 400 Bad Request", async ({ request }) => {
     expect(body.error).toEqual("Missing email or username");
 });
 
-test("POST /login no expone la contraseña en la respuesta", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("POST /login no expone la contraseña en la respuesta", async ({ apiClient, users }) => {
     const response = await apiClient.login(users.validUser);
     const body = await response.json();
 

--- a/tests-api/tests/security/login.security.spec.ts
+++ b/tests-api/tests/security/login.security.spec.ts
@@ -1,6 +1,4 @@
-import { test, expect } from "@playwright/test";
-import { ApiClient } from "../../apiClient";
-import users from "../../fixtures/users.json";
+import { test, expect } from "../../fixtures/apiClient.fixture";
 
 // 1. Intentos de login con datos maliciosos
 const maliciousInputs = [
@@ -10,8 +8,7 @@ const maliciousInputs = [
 ];
 
 maliciousInputs.forEach((input, idx) => {
-  test(`Seguridad: login rechaza datos maliciosos (${idx + 1})`, async ({ request }) => {
-    const apiClient = new ApiClient(request);
+  test(`Seguridad: login rechaza datos maliciosos (${idx + 1})`, async ({ apiClient }) => {
     const response = await apiClient.login(input);
     expect(response.status()).toBe(400);
     const body = await response.json();
@@ -20,8 +17,7 @@ maliciousInputs.forEach((input, idx) => {
 });
 
 // 2. Fuerza bruta (simulación de múltiples intentos fallidos)
-test("Seguridad: login rechaza múltiples intentos fallidos", async ({ request }) => {
-  const apiClient = new ApiClient(request);
+test("Seguridad: login rechaza múltiples intentos fallidos", async ({ apiClient }) => {
   for (let i = 0; i < 5; i++) {
     const response = await apiClient.login({ email: "noexiste@mock-prueba.in", password: "wrong" });
     expect(response.status()).toBe(400);
@@ -31,8 +27,7 @@ test("Seguridad: login rechaza múltiples intentos fallidos", async ({ request }
 });
 
 // 3. Campos inesperados
-test("Seguridad: login ignora campos extra y no otorga privilegios", async ({ request }) => {
-  const apiClient = new ApiClient(request);
+test("Seguridad: login ignora campos extra y no otorga privilegios", async ({ apiClient, users }) => {
   const response = await apiClient.login({ ...users.validUser, admin: true });
   expect(response.status()).toBe(200);
   const body = await response.json();
@@ -40,8 +35,7 @@ test("Seguridad: login ignora campos extra y no otorga privilegios", async ({ re
 });
 
 // 4. Respuesta genérica en errores
-test("Seguridad: login no revela si el email existe", async ({ request }) => {
-  const apiClient = new ApiClient(request);
+test("Seguridad: login no revela si el email existe", async ({ apiClient }) => {
   const response = await apiClient.login({ email: "usuario@noexiste.com", password: "wrong" });
   expect(response.status()).toBe(400);
   const body = await response.json();
@@ -49,8 +43,7 @@ test("Seguridad: login no revela si el email existe", async ({ request }) => {
 });
 
 // 5. Tamaño de payload
-test("Seguridad: login rechaza payload muy grande", async ({ request }) => {
-  const apiClient = new ApiClient(request);
+test("Seguridad: login rechaza payload muy grande", async ({ apiClient }) => {
   const bigString = "a".repeat(2e6); // 2MB
   let response, error;
   try {
@@ -70,8 +63,7 @@ test("Seguridad: login rechaza payload muy grande", async ({ request }) => {
 });
 
 // 6. Validación de tipos
-test("Seguridad: login rechaza tipos incorrectos", async ({ request }) => {
-  const apiClient = new ApiClient(request);
+test("Seguridad: login rechaza tipos incorrectos", async ({ apiClient }) => {
   const response = await apiClient.login({ email: 12345, password: ["not", "a", "string"] });
   expect(response.status()).toBe(400);
   const body = await response.json();

--- a/tests-api/tests/users/users-schema.spec.ts
+++ b/tests-api/tests/users/users-schema.spec.ts
@@ -1,15 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../fixtures/apiClient.fixture";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import schema from "../../schemas/user-schema.json";
-import { ApiClient } from "../../apiClient";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
 const validate = ajv.compile(schema);
 
-test("GET /users → validación de esquema con AJV", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("GET /users → validación de esquema con AJV", async ({ apiClient }) => {
     const response = await apiClient.getUsers(2);
     expect(response.status()).toBe(200);
 

--- a/tests-api/tests/users/users.spec.ts
+++ b/tests-api/tests/users/users.spec.ts
@@ -1,8 +1,6 @@
-import { test, expect } from "@playwright/test";
-import { ApiClient } from "../../apiClient";
+import { test, expect } from "../../fixtures/apiClient.fixture";
 
-test("GET /users?page=2 válido → 200 OK + verificación array respuesta", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("GET /users?page=2 válido → 200 OK + verificación array respuesta", async ({ apiClient }) => {
     const response = await apiClient.getUsers(2);
 
     // Status esperado
@@ -29,9 +27,8 @@ test("GET /users?page=2 válido → 200 OK + verificación array respuesta", asy
     }
 });
 
-test("GET /users?page=2 → validación de paginación", async ({ request }) => {
+test("GET /users?page=2 → validación de paginación", async ({ apiClient }) => {
     const page = 2;
-    const apiClient = new ApiClient(request);
     const response = await apiClient.getUsers(page);
 
     expect(response.status()).toBe(200);
@@ -54,8 +51,7 @@ test("GET /users?page=2 → validación de paginación", async ({ request }) => 
     expect(body.data.length).toBeGreaterThan(0);
 });
 
-test("GET /users/23 → 404 Usuario no existe", async ({ request }) => {
-    const apiClient = new ApiClient(request);
+test("GET /users/23 → 404 Usuario no existe", async ({ apiClient }) => {
     const response = await apiClient.getUser(23);
 
     //Validamos el status code


### PR DESCRIPTION
## Summary
- add a shared Playwright fixture that exposes an ApiClient instance and user fixtures
- refactor API suites to consume the fixture instead of manually instantiating ApiClient and importing users.json

## Testing
- npm run test:api

------
https://chatgpt.com/codex/tasks/task_e_68e5de020d808331951a20818a9c8311