### PR TITLE
Explain corrupt JSON login test payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ npx playwright test
 npx playwright test tests-api/tests/login.spec.ts
 ```
 
+> ℹ️ Las suites de API validan tanto escenarios exitosos como de error, incluyendo la resiliencia del endpoint frente a bodies JSON corruptos.
+
 ### 🔹 Generar un reporte en HTML
 ```bash
 npx playwright test --reporter=html

--- a/tests-api/tests/login/login.spec.ts
+++ b/tests-api/tests/login/login.spec.ts
@@ -49,3 +49,22 @@ test("POST /login no expone la contraseña en la respuesta", async ({ apiClient,
     expect(body).not.toHaveProperty("password");
 });
 
+test("POST /login con JSON corrupto → 400 Bad Request", async ({ request }) => {
+    const response = await request.post("/api/login", {
+        headers: {
+            "Content-Type": "application/json",
+            "x-api-key": "mock-prueba-free-v1",
+        },
+        // Playwright envuelve los strings en comillas cuando se usa `data`. Al mandar el payload
+        // como Buffer lo enviamos en crudo para que el servidor reciba realmente `{bad json` y
+        // dispare el handler de JSON inválido.
+        data: Buffer.from("{bad json"),
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body).toMatchObject({ error: "Invalid JSON payload" });
+});
+


### PR DESCRIPTION
## Summary
- clarify the corrupt login payload test by documenting why the request body is sent as a Buffer

## Testing
- npx playwright test tests-api/tests/login/login.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5e5555f5483319155300bd971f5af